### PR TITLE
implement Entry Proxy in Go

### DIFF
--- a/entry_proxy/main.go
+++ b/entry_proxy/main.go
@@ -65,6 +65,7 @@ func netCopy(from, to net.Conn, finished chan<- struct{}) {
 
 func processRequest(clientConn net.Conn) {
     defer clientConn.Close()
+    clientConn.SetReadDeadline(time.Now().Add(*timeout))
     hostname, clientConn, err := sni.ServerNameFromConn(clientConn)
     if err != nil {
         log.Printf("Unable to get target server name from SNI: %s", err)

--- a/entry_proxy/main.go
+++ b/entry_proxy/main.go
@@ -99,7 +99,7 @@ func main() {
     flag.Parse()
     listener, err := net.Listen("tcp", *listenOn)
     if err != nil {
-        log.Fatal("Unable to listen on %s: %s", *listenOn, err)
+        log.Fatalf("Unable to listen on %s: %s", *listenOn, err)
     }
     for {
         conn, err := listener.Accept()

--- a/entry_proxy/main.go
+++ b/entry_proxy/main.go
@@ -22,7 +22,7 @@ import (
 
 var (
     proxyUrl = flag.String("proxy", "socks5://127.0.0.1:9050", "Proxy URL")
-    listenOn = flag.String("listen-on", "0.0.0.0:443", "Where to listen")
+    listenOn = flag.String("listen-on", ":443", "Where to listen")
     onionPort = flag.Int("onion-port", 443, "Port on onion site to use")
     bufferSize = flag.Int("buffer-size", 1024, "Proxy buffer size, bytes")
 )

--- a/entry_proxy/main.go
+++ b/entry_proxy/main.go
@@ -1,0 +1,112 @@
+package main
+
+/*  Entry Proxy for Onion Gateway
+
+See also:
+
+  * https://github.com/DonnchaC/oniongateway/blob/master/docs/design.rst#32-entry-proxy
+  * https://gist.github.com/Yawning/bac58e08a05fc378a8cc (SOCKS5 client, Tor)
+  * https://habrahabr.ru/post/142527/ (TCP proxy)
+*/
+
+import (
+    "flag"
+    "log"
+    "net"
+    "net/url"
+    "strconv"
+    "time"
+
+    "github.com/polvi/sni"
+    "golang.org/x/net/proxy"
+)
+
+var (
+    proxyUrl = flag.String("proxy", "socks5://127.0.0.1:9050", "Proxy URL")
+    listenOn = flag.String("listen-on", "0.0.0.0:443", "Where to listen")
+    onionPort = flag.Int("onion-port", 443, "Port on onion site to use")
+    bufferSize = flag.Int("buffer-size", 1024, "Proxy buffer size, bytes")
+    timeout = flag.Duration("timeout", 60 * time.Second, "Timeout for IO")
+)
+
+func connectToProxy(targetServer string) (net.Conn, error) {
+    parsedUrl, err := url.Parse(*proxyUrl)
+    if err != nil {
+        return nil, err
+    }
+    dialer, err := proxy.FromURL(parsedUrl, proxy.Direct)
+    if err != nil {
+        return nil, err
+    }
+    connection, err := dialer.Dial("tcp", targetServer)
+    return connection, err
+}
+
+func netCopy(from, to net.Conn, finished chan<- struct{}) {
+    defer func() {
+        finished<-struct{}{}
+    }()
+    buffer := make([]byte, *bufferSize)
+    for {
+        from.SetReadDeadline(time.Now().Add(*timeout))
+        bytesRead, err := from.Read(buffer)
+        if err != nil {
+            log.Printf("Finished reading: %s", err)
+            break
+        }
+        to.SetWriteDeadline(time.Now().Add(*timeout))
+        _, err = to.Write(buffer[:bytesRead])
+        if err != nil {
+            log.Printf("Finished writting: %s", err)
+            break
+        }
+    }
+}
+
+func processRequest(clientConn net.Conn) {
+    defer clientConn.Close()
+    hostname, clientConn, err := sni.ServerNameFromConn(clientConn)
+    if err != nil {
+        log.Printf("Unable to get target server name from SNI: %s", err)
+        return
+    }
+    onion, err := resolveToOnion(hostname)
+    if err != nil {
+        log.Printf("Unable to resolve %s using DNS TXT: %s", hostname, err)
+        return
+    }
+    log.Printf("%s was resolved to %s", hostname, onion)
+    targetServer := net.JoinHostPort(onion, strconv.Itoa(*onionPort))
+    serverConn, err := connectToProxy(targetServer)
+    if err != nil {
+        log.Printf(
+            "Unable to connect to %s through %s: %s\n",
+            targetServer,
+            *proxyUrl,
+            err,
+        )
+        return
+    }
+    defer serverConn.Close()
+    finished := make(chan struct{})
+    go netCopy(clientConn, serverConn, finished)
+    go netCopy(serverConn, clientConn, finished)
+    <-finished
+    <-finished
+}
+
+func main() {
+    flag.Parse()
+    listener, err := net.Listen("tcp", *listenOn)
+    if err != nil {
+        log.Fatal("Unable to listen on %s: %s", *listenOn, err)
+    }
+    for {
+        conn, err := listener.Accept()
+        if err == nil {
+            go processRequest(conn)
+        } else {
+            log.Printf("Unable to accept request: %s", err)
+        }
+    }
+}

--- a/entry_proxy/main_test.go
+++ b/entry_proxy/main_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+    "net"
+    "testing"
+)
+
+func TestNetCopy(t *testing.T) {
+    listener, err := net.Listen("tcp", "127.0.0.1:0") // pick free port
+    if err != nil {
+        t.Fatal(err)
+    }
+    defer listener.Close()
+    go func() {
+        conn, err := listener.Accept()
+        if err != nil {
+            t.Fatal(err)
+        }
+        defer conn.Close()
+        // write
+        for i := 0; i < 10000; i++ {
+            conn.Write([]byte("AAA"))
+        }
+        // read and check
+        buffer := make([]byte, 3)
+        for i := 0; i < 10000; i++ {
+            bytesRead, err := conn.Read(buffer)
+            if err != nil {
+                t.Fatal(err)
+            }
+            if bytesRead != 3 {
+                t.Fatalf("Mismatch in bytesRead. Expected %d, got %d", 3, bytesRead)
+            }
+            if string(buffer) != "AAA" {
+                t.Fatalf("Mismatch. Expected %q, got %q", "AAA", buffer)
+            }
+        }
+    }()
+    // echo client
+    client, err := net.Dial("tcp", listener.Addr().String())
+    if err != nil {
+        t.Fatal(err)
+    }
+    finished := make(chan struct{})
+    go netCopy(client, client, finished)
+    <-finished
+}

--- a/entry_proxy/resolve_to_onion.go
+++ b/entry_proxy/resolve_to_onion.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+    "errors"
+    "fmt"
+    "net"
+    "regexp"
+)
+
+var onionTxtRe *regexp.Regexp
+const SUBMATCH_OF_INTEREST = 2 // see onionTxtRe
+
+func resolveToOnion(hostname string) (onion string, err error) {
+    if onionTxtRe == nil {
+        // FIXME: races?
+        onionTxtRe, err = regexp.Compile("(^| )onion=([a-z0-9]{16}.onion)( |$)")
+        if err != nil {
+            return
+        }
+    }
+    txts, err := net.LookupTXT(hostname)
+    if err != nil {
+        return
+    }
+    if len(txts) == 0 {
+        err = errors.New(fmt.Sprintf("No TXT records for %s", hostname))
+        return
+    }
+    for _, txt := range txts {
+        match := onionTxtRe.FindStringSubmatch(txt)
+        if match != nil {
+            return match[SUBMATCH_OF_INTEREST], nil
+        }
+    }
+    return "", errors.New(fmt.Sprintf("No suitable TXT records for %s", hostname))
+}


### PR DESCRIPTION
This work is not finished!

Testing:
- **DNS rules for the domain**. I added domain `test-ssl.pasta.cf` with A record "127.0.0.1" and TXT record "onion=pokodugigmf66twh.onion".
- **Server**. Onion site pokodugigmf66twh.onion was created (`HiddenServicePort 4218 127.0.0.1:4218`). For testing purposes I used port 4218 rather than 443. `nginx` listens on port 4218 and provides access to back-end of my pastebin like site pasta.cf.
- **Local setup**. Compiled tool `entry_proxy` with `go get && go install`. Run: `entry_proxy -listen-on 127.0.0.1:4218 -onion-port 4218`. In curl `curl --insecure https://test-ssl.pasta.cf:4218`. It works!

My next step is to run `entry_proxy` on some public VPS and to set A record of the domain to IP address of that VPS. By the way, we can add IPv6 addresses as well.

Previous repository for this code: https://github.com/starius/epog
