### PR TITLE
add appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,25 @@
+clone_folder: c:\gopath\src\github.com\DonnchaC\oniongateway
+
+environment:
+  GOPATH: c:\gopath
+
+install:
+  - echo %PATH%
+  - echo %GOPATH%
+  - go version
+  - go env
+  - go get golang.org/x/tools/cmd/cover
+  - go get github.com/mattn/goveralls
+
+build_script:
+  - go get github.com/DonnchaC/oniongateway/entry_proxy
+  - >
+      go test -v
+      github.com/DonnchaC/oniongateway/entry_proxy
+      -covermode=count
+      -coverprofile=coverage.out
+  - >
+      %GOPATH%/bin/goveralls
+      -coverprofile=coverage.out
+      -service=appveyor-ci
+      -repotoken=%COVERALLS_TOKEN%


### PR DESCRIPTION
Based on https://github.com/oschwald/maxminddb-golang/blob/f4aa55714a3f843869ca9a38625e177a627c1ce6/appveyor.yml

I enabled the repo in AppVeyor and added `COVERALLS_TOKEN` to [AppVeyor's variables](https://ci.appveyor.com/project/starius/oniongateway/settings/environment).
