### PR TITLE
add tool check_entry_proxy

### DIFF
--- a/check_entry_proxy/checker.go
+++ b/check_entry_proxy/checker.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"io/ioutil"
-	"math/rand"
 	"net"
 	"net/http"
 	"net/url"
@@ -23,6 +22,7 @@ type Checker struct {
 	Rules         []Rule
 	RedirectRules []string
 	Dial          func(network, addr string) (net.Conn, error)
+	RandIntn      func(n int) int
 }
 
 func (c *Checker) makeHTTPClient(address string) (http.Client, error) {
@@ -45,7 +45,7 @@ func (c *Checker) chooseRule() (Rule, error) {
 	if len(c.Rules) == 0 {
 		return Rule{}, fmt.Errorf("Set of rules to check is empty")
 	}
-	ruleIndex := rand.Intn(len(c.Rules))
+	ruleIndex := c.RandIntn(len(c.Rules))
 	return c.Rules[ruleIndex], nil
 }
 
@@ -53,7 +53,7 @@ func (c *Checker) chooseRedirectURL() (*url.URL, error) {
 	if len(c.RedirectRules) == 0 {
 		return nil, fmt.Errorf("Set of redirect URLs to check is empty")
 	}
-	ruleIndex := rand.Intn(len(c.RedirectRules))
+	ruleIndex := c.RandIntn(len(c.RedirectRules))
 	rawurl := c.RedirectRules[ruleIndex]
 	return url.Parse(rawurl)
 }

--- a/check_entry_proxy/checker.go
+++ b/check_entry_proxy/checker.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"math/rand"
@@ -9,10 +8,6 @@ import (
 	"net/http"
 	"strings"
 )
-
-func errorf(message string, args ...interface{}) error {
-	return errors.New(fmt.Sprintf(message, args...))
-}
 
 type Rule struct {
 	Url          string
@@ -39,7 +34,7 @@ func (c *Checker) makeHttpClient(address string) (http.Client, error) {
 
 func (c *Checker) chooseRule() (Rule, error) {
 	if len(c.Rules) == 0 {
-		return Rule{}, errors.New("Set of rules to check is empty")
+		return Rule{}, fmt.Errorf("Set of rules to check is empty")
 	}
 	ruleIndex := rand.Intn(len(c.Rules))
 	return c.Rules[ruleIndex], nil
@@ -60,7 +55,7 @@ func getResponse(rule Rule, client http.Client) (string, error) {
 
 func checkResponse(rule Rule, body string) error {
 	if !strings.Contains(body, rule.ExpectedText) {
-		return errorf(
+		return fmt.Errorf(
 			"Responce body %q of URL %s does not contain expected text %q",
 			body,
 			rule.Url,
@@ -73,18 +68,18 @@ func checkResponse(rule Rule, body string) error {
 func (c *Checker) CheckEntryProxy(address string) error {
 	client, err := c.makeHttpClient(address)
 	if err != nil {
-		return errorf("Unable to create HTTP client: %s", err)
+		return fmt.Errorf("Unable to create HTTP client: %s", err)
 	}
 	rule, err := c.chooseRule()
 	if err != nil {
-		return errorf("Unable to choose rule: %s", err)
+		return fmt.Errorf("Unable to choose rule: %s", err)
 	}
 	body, err := getResponse(rule, client)
 	if err != nil {
-		return errorf("Unable to get download: %s", err)
+		return fmt.Errorf("Unable to get download: %s", err)
 	}
 	if err := checkResponse(rule, body); err != nil {
-		return errorf("Check failed: %s", err)
+		return fmt.Errorf("Check failed: %s", err)
 	}
 	return nil
 }

--- a/check_entry_proxy/checker.go
+++ b/check_entry_proxy/checker.go
@@ -78,7 +78,7 @@ func (c *Checker) CheckEntryProxy(address string) error {
 	}
 	body, err := getResponse(rule, client)
 	if err != nil {
-		return fmt.Errorf("Unable to get download: %s", err)
+		return fmt.Errorf("Unable to download: %s", err)
 	}
 	if err := checkResponse(rule, body); err != nil {
 		return fmt.Errorf("Check failed: %s", err)

--- a/check_entry_proxy/checker.go
+++ b/check_entry_proxy/checker.go
@@ -41,8 +41,8 @@ func (c *Checker) chooseRule() (Rule, error) {
 	return c.Rules[ruleIndex], nil
 }
 
-func getResponse(rule Rule, client http.Client) (string, error) {
-	response, err := client.Get(rule.URL)
+func getResponse(url string, client http.Client) (string, error) {
+	response, err := client.Get(url)
 	if err != nil {
 		return "", err
 	}
@@ -76,7 +76,7 @@ func (c *Checker) CheckEntryProxy(address string) error {
 	if err != nil {
 		return fmt.Errorf("Unable to choose rule: %s", err)
 	}
-	body, err := getResponse(rule, client)
+	body, err := getResponse(rule.URL, client)
 	if err != nil {
 		return fmt.Errorf("Unable to download: %s", err)
 	}

--- a/check_entry_proxy/checker.go
+++ b/check_entry_proxy/checker.go
@@ -41,17 +41,17 @@ func (c *Checker) chooseRule() (Rule, error) {
 	return c.Rules[ruleIndex], nil
 }
 
-func getResponse(url string, client http.Client) (string, error) {
+func getResponse(url string, client http.Client) (string, *http.Response, error) {
 	response, err := client.Get(url)
 	if err != nil {
-		return "", err
+		return "", response, err
 	}
 	defer response.Body.Close()
 	body, err := ioutil.ReadAll(response.Body)
 	if err != nil {
-		return "", err
+		return "", response, err
 	}
-	return string(body), nil
+	return string(body), response, nil
 }
 
 func checkResponse(rule Rule, body string) error {
@@ -76,7 +76,7 @@ func (c *Checker) CheckEntryProxy(address string) error {
 	if err != nil {
 		return fmt.Errorf("Unable to choose rule: %s", err)
 	}
-	body, err := getResponse(rule.URL, client)
+	body, _, err := getResponse(rule.URL, client)
 	if err != nil {
 		return fmt.Errorf("Unable to download: %s", err)
 	}

--- a/check_entry_proxy/checker.go
+++ b/check_entry_proxy/checker.go
@@ -9,24 +9,25 @@ import (
 	"strings"
 )
 
+// Rule for checker: URL and text expected to be found in response
 type Rule struct {
-	Url          string
+	URL          string
 	ExpectedText string
 }
 
+// Checker for entry_proxy
 type Checker struct {
 	Rules []Rule
 	Dial  func(network, addr string) (net.Conn, error)
 }
 
-func (c *Checker) makeHttpClient(address string) (http.Client, error) {
+func (c *Checker) makeHTTPClient(address string) (http.Client, error) {
 	transport := &http.Transport{
 		Dial: func(network, _ string) (net.Conn, error) {
 			if c.Dial != nil {
 				return c.Dial(network, address)
-			} else {
-				return net.Dial(network, address)
 			}
+			return net.Dial(network, address)
 		},
 	}
 	return http.Client{Transport: transport}, nil
@@ -41,7 +42,7 @@ func (c *Checker) chooseRule() (Rule, error) {
 }
 
 func getResponse(rule Rule, client http.Client) (string, error) {
-	response, err := client.Get(rule.Url)
+	response, err := client.Get(rule.URL)
 	if err != nil {
 		return "", err
 	}
@@ -58,15 +59,16 @@ func checkResponse(rule Rule, body string) error {
 		return fmt.Errorf(
 			"Responce body %q of URL %s does not contain expected text %q",
 			body,
-			rule.Url,
+			rule.URL,
 			rule.ExpectedText,
 		)
 	}
 	return nil
 }
 
+// CheckEntryProxy checks entry_proxy instance
 func (c *Checker) CheckEntryProxy(address string) error {
-	client, err := c.makeHttpClient(address)
+	client, err := c.makeHTTPClient(address)
 	if err != nil {
 		return fmt.Errorf("Unable to create HTTP client: %s", err)
 	}

--- a/check_entry_proxy/checker.go
+++ b/check_entry_proxy/checker.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"net"
+	"net/http"
+	"strings"
+)
+
+func errorf(message string, args ...interface{}) error {
+	return errors.New(fmt.Sprintf(message, args...))
+}
+
+type Rule struct {
+	Url          string
+	ExpectedText string
+}
+
+type Checker struct {
+	Rules []Rule
+	Dial  func(network, addr string) (net.Conn, error)
+}
+
+func (c *Checker) makeHttpClient(address string) (http.Client, error) {
+	transport := &http.Transport{
+		Dial: func(network, _ string) (net.Conn, error) {
+			if c.Dial != nil {
+				return c.Dial(network, address)
+			} else {
+				return net.Dial(network, address)
+			}
+		},
+	}
+	return http.Client{Transport: transport}, nil
+}
+
+func (c *Checker) chooseRule() (Rule, error) {
+	if len(c.Rules) == 0 {
+		return Rule{}, errors.New("Set of rules to check is empty")
+	}
+	ruleIndex := rand.Intn(len(c.Rules))
+	return c.Rules[ruleIndex], nil
+}
+
+func getResponse(rule Rule, client http.Client) (string, error) {
+	response, err := client.Get(rule.Url)
+	if err != nil {
+		return "", err
+	}
+	defer response.Body.Close()
+	body, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return "", err
+	}
+	return string(body), nil
+}
+
+func checkResponse(rule Rule, body string) error {
+	if !strings.Contains(body, rule.ExpectedText) {
+		return errorf(
+			"Responce body %q of URL %s does not contain expected text %q",
+			body,
+			rule.Url,
+			rule.ExpectedText,
+		)
+	}
+	return nil
+}
+
+func (c *Checker) CheckEntryProxy(address string) error {
+	client, err := c.makeHttpClient(address)
+	if err != nil {
+		return errorf("Unable to create HTTP client: %s", err)
+	}
+	rule, err := c.chooseRule()
+	if err != nil {
+		return errorf("Unable to choose rule: %s", err)
+	}
+	body, err := getResponse(rule, client)
+	if err != nil {
+		return errorf("Unable to get download: %s", err)
+	}
+	if err := checkResponse(rule, body); err != nil {
+		return errorf("Check failed: %s", err)
+	}
+	return nil
+}

--- a/check_entry_proxy/checker.yaml
+++ b/check_entry_proxy/checker.yaml
@@ -1,0 +1,10 @@
+rules:
+    - url: https://www.pasta.cf/mind-take-boyfriend/raw
+      expectedtext: entry_proxy
+
+    - url: https://www.pasta.cf/hey-aim-slap
+      expectedtext: another test
+
+redirectrules:
+    - http://example.com/foo
+    - http://site.com/

--- a/check_entry_proxy/checker_test.go
+++ b/check_entry_proxy/checker_test.go
@@ -8,19 +8,18 @@ import (
 	"testing"
 )
 
-const expectedText = "test passed"
 const anyProxy = "1.2.3.4:5678"
 
-func TestCheckEntryProxy(t *testing.T) {
+func makeMockChecker(expectedText, observedText string) *Checker {
 	// TODO NewTLSServer
 	ts := httptest.NewServer(
 		http.HandlerFunc(
 			func(w http.ResponseWriter, r *http.Request) {
-				fmt.Fprintln(w, expectedText)
+				fmt.Fprintln(w, observedText)
 			},
 		),
 	)
-	checker := &Checker{
+	return &Checker{
 		Rules: []Rule{
 			{"http://example.com/", expectedText},
 		},
@@ -28,9 +27,21 @@ func TestCheckEntryProxy(t *testing.T) {
 			return net.Dial(network, ts.Listener.Addr().String())
 		},
 	}
+}
+
+func TestCheckEntryProxy(t *testing.T) {
+	checker := makeMockChecker("test passed", "test passed")
 	err := checker.CheckEntryProxy(anyProxy)
 	if err != nil {
 		t.Fatalf("Always passing test failed: %s", err)
+	}
+}
+
+func TestCheckEntryProxyFail(t *testing.T) {
+	checker := makeMockChecker("expected", "observed")
+	err := checker.CheckEntryProxy(anyProxy)
+	if err == nil {
+		t.Fatalf("checker did not fail with bad entry_proxy: %s", err)
 	}
 }
 

--- a/check_entry_proxy/checker_test.go
+++ b/check_entry_proxy/checker_test.go
@@ -10,7 +10,7 @@ import (
 
 const anyProxy = "1.2.3.4:5678"
 
-func makeHttpServer(observedText string) *httptest.Server {
+func makeHTTPServer(observedText string) *httptest.Server {
 	// TODO NewTLSServer
 	return httptest.NewServer(
 		http.HandlerFunc(
@@ -22,7 +22,7 @@ func makeHttpServer(observedText string) *httptest.Server {
 }
 
 func makeMockChecker(expectedText, observedText, url string) *Checker {
-	ts := makeHttpServer(observedText)
+	ts := makeHTTPServer(observedText)
 	return &Checker{
 		Rules: []Rule{
 			{url, expectedText},
@@ -75,7 +75,7 @@ func makeRealChecker(
 	checker *Checker,
 	proxy string,
 ) {
-	ts := makeHttpServer(observedText)
+	ts := makeHTTPServer(observedText)
 	checker = &Checker{
 		Rules: []Rule{
 			{"http://example.com/", expectedText},

--- a/check_entry_proxy/checker_test.go
+++ b/check_entry_proxy/checker_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+const expectedText = "test passed"
+const anyProxy = "1.2.3.4:5678"
+
+func TestCheckEntryProxy(t *testing.T) {
+	// TODO NewTLSServer
+	ts := httptest.NewServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprintln(w, expectedText)
+			},
+		),
+	)
+	checker := &Checker{
+		Rules: []Rule{
+			{"http://example.com/", expectedText},
+		},
+		Dial: func(network, addr string) (net.Conn, error) {
+			return net.Dial(network, ts.Listener.Addr().String())
+		},
+	}
+	err := checker.CheckEntryProxy(anyProxy)
+	if err != nil {
+		t.Fatalf("Always passing test failed: %s", err)
+	}
+}
+
+func TestCheckEntryProxyEmptyRules(t *testing.T) {
+	checker := &Checker{}
+	err := checker.CheckEntryProxy(anyProxy)
+	if err == nil {
+		t.Fatal("checker did not fail with empty list of rules")
+	}
+}

--- a/check_entry_proxy/checker_test.go
+++ b/check_entry_proxy/checker_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"math/rand"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -35,6 +36,7 @@ func makeMockChecker(
 		Dial: func(network, addr string) (net.Conn, error) {
 			return net.Dial(network, server.Listener.Addr().String())
 		},
+		RandIntn: rand.Intn,
 	}
 	return
 }
@@ -90,6 +92,7 @@ func makeRealChecker(
 		Rules: []Rule{
 			{"http://example.com/", expectedText},
 		},
+		RandIntn: rand.Intn,
 	}
 	proxy = server.Listener.Addr().String()
 	return
@@ -164,6 +167,7 @@ func TestCheckRedirect(t *testing.T) {
 		RedirectRules: []string{
 			"http://example.com/foo",
 		},
+		RandIntn: rand.Intn,
 	}
 	redirectLocation := server.Listener.Addr().String()
 	host, _ := getHostPort(redirectLocation)
@@ -180,6 +184,7 @@ func TestCheckRedirectNonStandardPort(t *testing.T) {
 		RedirectRules: []string{
 			"http://example.com/foo",
 		},
+		RandIntn: rand.Intn,
 	}
 	redirectLocation := server.Listener.Addr().String()
 	host, _ := getHostPort(redirectLocation)
@@ -196,6 +201,7 @@ func TestCheckRedirectOtherHost(t *testing.T) {
 		RedirectRules: []string{
 			"http://example.com/foo",
 		},
+		RandIntn: rand.Intn,
 	}
 	redirectLocation := server.Listener.Addr().String()
 	host, _ := getHostPort(redirectLocation)
@@ -212,6 +218,7 @@ func TestCheckRedirectOtherPort(t *testing.T) {
 		RedirectRules: []string{
 			"http://example.com/foo",
 		},
+		RandIntn: rand.Intn,
 	}
 	redirectLocation := server.Listener.Addr().String()
 	host, _ := getHostPort(redirectLocation)
@@ -228,6 +235,7 @@ func TestCheckRedirectOtherHTTPStatus(t *testing.T) {
 		RedirectRules: []string{
 			"http://example.com/foo",
 		},
+		RandIntn: rand.Intn,
 	}
 	redirectLocation := server.Listener.Addr().String()
 	host, _ := getHostPort(redirectLocation)

--- a/check_entry_proxy/main.go
+++ b/check_entry_proxy/main.go
@@ -3,7 +3,10 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"os"
+
+	"gopkg.in/yaml.v2"
 )
 
 var (
@@ -22,18 +25,37 @@ var (
 		80,
 		"HTTP port redirecting to entry proxy",
 	)
+	config = flag.String(
+		"config",
+		"",
+		"config file with rules in YAML format",
+	)
 )
 
 func main() {
 	flag.Parse()
-	checker := &Checker{
-		// TODO: move to flag
-		Rules: []Rule{
-			{"https://www.pasta.cf/mind-take-boyfriend/raw", "entry_proxy"},
-		},
-		RedirectRules: []string{
-			"http://example.com/foo",
-		},
+	var checker Checker
+	if *config != "" {
+		configData, err := ioutil.ReadFile(*config)
+		if err != nil {
+			fmt.Printf("Error reading config %s: %s\n", *config, err)
+			os.Exit(1)
+		}
+		err = yaml.Unmarshal(configData, &checker)
+		if err != nil {
+			fmt.Printf("Error parsing config %s: %s\n", *config, err)
+			os.Exit(1)
+		}
+	} else {
+		// default values
+		checker = Checker{
+			Rules: []Rule{
+				{"https://www.pasta.cf/mind-take-boyfriend/raw", "entry_proxy"},
+			},
+			RedirectRules: []string{
+				"http://example.com/foo",
+			},
+		}
 	}
 	err := checker.CheckHost(*host, *proxyPort, *redirectPort)
 	if err == nil {

--- a/check_entry_proxy/main.go
+++ b/check_entry_proxy/main.go
@@ -1,95 +1,10 @@
 package main
 
 import (
-	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
-	"math/rand"
-	"net"
-	"net/http"
 	"os"
-	"strings"
 )
-
-func errorf(message string, args ...interface{}) error {
-	return errors.New(fmt.Sprintf(message, args...))
-}
-
-type Rule struct {
-	Url          string
-	ExpectedText string
-}
-
-type Checker struct {
-	Rules []Rule
-	Dial  func(network, addr string) (net.Conn, error)
-}
-
-func (c *Checker) makeHttpClient(address string) (http.Client, error) {
-	transport := &http.Transport{
-		Dial: func(network, _ string) (net.Conn, error) {
-			if c.Dial != nil {
-				return c.Dial(network, address)
-			} else {
-				return net.Dial(network, address)
-			}
-		},
-	}
-	return http.Client{Transport: transport}, nil
-}
-
-func (c *Checker) chooseRule() (Rule, error) {
-	if len(c.Rules) == 0 {
-		return Rule{}, errors.New("Set of rules to check is empty")
-	}
-	ruleIndex := rand.Intn(len(c.Rules))
-	return c.Rules[ruleIndex], nil
-}
-
-func getResponse(rule Rule, client http.Client) (string, error) {
-	response, err := client.Get(rule.Url)
-	if err != nil {
-		return "", err
-	}
-	defer response.Body.Close()
-	body, err := ioutil.ReadAll(response.Body)
-	if err != nil {
-		return "", err
-	}
-	return string(body), nil
-}
-
-func checkResponse(rule Rule, body string) error {
-	if !strings.Contains(body, rule.ExpectedText) {
-		return errorf(
-			"Responce body %q of URL %s does not contain expected text %q",
-			body,
-			rule.Url,
-			rule.ExpectedText,
-		)
-	}
-	return nil
-}
-
-func (c *Checker) CheckEntryProxy(address string) error {
-	client, err := c.makeHttpClient(address)
-	if err != nil {
-		return errorf("Unable to create HTTP client: %s", err)
-	}
-	rule, err := c.chooseRule()
-	if err != nil {
-		return errorf("Unable to choose rule: %s", err)
-	}
-	body, err := getResponse(rule, client)
-	if err != nil {
-		return errorf("Unable to get download: %s", err)
-	}
-	if err := checkResponse(rule, body); err != nil {
-		return errorf("Check failed: %s", err)
-	}
-	return nil
-}
 
 var (
 	entryProxy = flag.String("entry-proxy", ":443", "Entry proxy to test")

--- a/check_entry_proxy/main.go
+++ b/check_entry_proxy/main.go
@@ -1,13 +1,23 @@
 package main
 
 import (
+	"crypto/rand"
 	"flag"
 	"fmt"
 	"io/ioutil"
+	"math/big"
 	"os"
 
 	"gopkg.in/yaml.v2"
 )
+
+func cryptoRandInt(upperBound int) int {
+	value, err := rand.Int(rand.Reader, big.NewInt(int64(upperBound)))
+	if err != nil {
+		panic(err)
+	}
+	return int(value.Int64())
+}
 
 var (
 	host = flag.String(
@@ -57,6 +67,7 @@ func main() {
 			},
 		}
 	}
+	checker.RandIntn = cryptoRandInt
 	err := checker.CheckHost(*host, *proxyPort, *redirectPort)
 	if err == nil {
 		fmt.Printf("OK\n")

--- a/check_entry_proxy/main.go
+++ b/check_entry_proxy/main.go
@@ -7,7 +7,21 @@ import (
 )
 
 var (
-	entryProxy = flag.String("entry-proxy", ":443", "Entry proxy to test")
+	host = flag.String(
+		"host",
+		"127.0.0.1",
+		"Host of entry proxy to test",
+	)
+	proxyPort = flag.Int(
+		"proxy-port",
+		443,
+		"HTTPS port of entry proxy",
+	)
+	redirectPort = flag.Int(
+		"redirect-port",
+		80,
+		"HTTP port redirecting to entry proxy",
+	)
 )
 
 func main() {
@@ -17,8 +31,11 @@ func main() {
 		Rules: []Rule{
 			{"https://www.pasta.cf/mind-take-boyfriend/raw", "entry_proxy"},
 		},
+		RedirectRules: []string{
+			"http://example.com/foo",
+		},
 	}
-	err := checker.CheckEntryProxy(*entryProxy)
+	err := checker.CheckHost(*host, *proxyPort, *redirectPort)
 	if err == nil {
 		fmt.Printf("OK\n")
 	} else {

--- a/check_entry_proxy/main.go
+++ b/check_entry_proxy/main.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+)
+
+type Rule struct {
+	Url          string
+	ExpectedText string
+}
+
+type Checker struct {
+	Rules []Rule
+	Dial  func(network, addr string) (net.Conn, error)
+}
+
+func (c *Checker) CheckEntryProxy(address string) error {
+	// make HTTP client
+	transport := &http.Transport{
+		Dial: func(network, _ string) (net.Conn, error) {
+			if c.Dial != nil {
+				return c.Dial(network, address)
+			} else {
+				return net.Dial(network, address)
+			}
+		},
+	}
+	client := &http.Client{Transport: transport}
+	// choose URL
+	if len(c.Rules) == 0 {
+		return errors.New("Set of rules to check is empty")
+	}
+	ruleIndex := rand.Intn(len(c.Rules))
+	rule := c.Rules[ruleIndex]
+	// request and check response body
+	response, err := client.Get(rule.Url)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+	body, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return err
+	}
+	if !strings.Contains(string(body), rule.ExpectedText) {
+		return errors.New(
+			fmt.Sprintf(
+				"Responce body %q of URL %s proxied through %s "+
+					"does not contain expected text %q",
+				response,
+				rule.Url,
+				address,
+				rule.ExpectedText,
+			),
+		)
+	}
+	return nil
+}
+
+var (
+	entryProxy = flag.String("entry-proxy", ":443", "Entry proxy to test")
+)
+
+func main() {
+	flag.Parse()
+	checker := &Checker{
+		// TODO: move to flag
+		Rules: []Rule{
+			{"https://www.pasta.cf/mind-take-boyfriend/raw", "entry_proxy"},
+		},
+	}
+	err := checker.CheckEntryProxy(*entryProxy)
+	if err == nil {
+		fmt.Printf("OK\n")
+	} else {
+		fmt.Printf("Error: %s\n", err)
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
How to use the tool:

``` bash
$ check_entry_proxy -entry-proxy 94.102.53.178:443
OK
$ check_entry_proxy -entry-proxy 94.102.53.178:80
Error: Unable to get download: Get https://www.pasta.cf/mind-take-boyfriend/raw: http: server gave HTTP response to HTTPS client
```

fix https://github.com/DonnchaC/oniongateway/issues/8
