### PR TITLE
entry_proxy: pass ACME challenges to HTTPS proxy

### DIFF
--- a/entry_proxy/redirect_test.go
+++ b/entry_proxy/redirect_test.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"io/ioutil"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"testing"
 
@@ -51,5 +53,60 @@ func TestNewRedirect(t *testing.T) {
 	}
 	if nextURL.Host != host {
 		t.Fatalf("Expected host %q, but got %q", host, nextURL.Host)
+	}
+}
+
+func TestPassThrough(t *testing.T) {
+	const hostedString = "test string"
+	https_server := httptest.NewTLSServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				w.Write([]byte(hostedString))
+			},
+		),
+	)
+	defer https_server.Close()
+	https_hostPort := https_server.Listener.Addr().String()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	http_hostPort := listener.Addr().String()
+	defer listener.Close()
+	if err != nil {
+		t.Fatalf("Failed to create a listener: %s", err)
+	}
+	server, err := NewRedirect(http_hostPort, https_hostPort)
+	if err != nil {
+		t.Fatalf("Failed to create redirecting HTTP server: %s", err)
+	}
+	go server.Serve(listener)
+	// check what the server returns
+	hostAndPort := listener.Addr().String()
+	client := http.Client{CheckRedirect: util.IgnoreRedirect}
+	theURL := &url.URL{
+		Scheme: "http",
+		Host:   hostAndPort,
+		Path:   "/.well-known/acme-challenge/test",
+	}
+	response, err := client.Get(theURL.String())
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf(
+			"Wrong HTTP status returned: %d instead of %d",
+			response.StatusCode,
+			http.StatusOK,
+		)
+	}
+	body, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+	if string(body) != hostedString {
+		t.Fatalf(
+			"Wrong response: %q, expected %q",
+			body,
+			hostedString,
+		)
 	}
 }


### PR DESCRIPTION
Let's encrypt's verification involves HTTP GET of a file from target server with HTTP client which [doesn't follow redirects](https://community.letsencrypt.org/t/webroot-only-performs-http-01-challenge-which-doesnt-follow-http-redirects-to-https-site/5557/3).

See https://github.com/DonnchaC/oniongateway/issues/18
